### PR TITLE
Refine dark theme and add 'Todas' category filter

### DIFF
--- a/site.js
+++ b/site.js
@@ -27,10 +27,25 @@ function inicializarSite(){
   const cats = [...new Set(gifs.map(g=>g.categoria))].sort();
   const ul = document.getElementById('categorias');
   ul.innerHTML='';
+
+  const todas=document.createElement('li');
+  todas.textContent='Todas';
+  todas.classList.add('selected');
+  todas.onclick=()=>{
+    document.querySelectorAll('#categorias li').forEach(x=>x.classList.remove('selected'));
+    todas.classList.add('selected');
+    renderGifs(gifs);
+  };
+  ul.appendChild(todas);
+
   cats.forEach(cat=>{
     const li=document.createElement('li');
     li.textContent=cat;
-    li.onclick=()=>{document.querySelectorAll('#categorias li').forEach(x=>x.classList.remove('selected'));li.classList.add('selected');renderGifs(gifs.filter(g=>g.categoria===cat));};
+    li.onclick=()=>{
+      document.querySelectorAll('#categorias li').forEach(x=>x.classList.remove('selected'));
+      li.classList.add('selected');
+      renderGifs(gifs.filter(g=>g.categoria===cat));
+    };
     ul.appendChild(li);
   });
   renderGifs(gifs);

--- a/style.css
+++ b/style.css
@@ -1,1 +1,103 @@
-/* simplified style placeholder */
+body {
+  background: #000;
+  color: #fff;
+  font-family: Arial, sans-serif;
+  margin: 0;
+}
+
+header {
+  padding: 20px;
+  text-align: center;
+  background: #111;
+}
+
+#busca {
+  padding: 6px 8px;
+  border-radius: 4px;
+  border: 1px solid #444;
+  background: #222;
+  color: #fff;
+}
+
+nav ul {
+  list-style: none;
+  margin: 10px 0 0;
+  padding: 0;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+}
+
+nav li {
+  margin: 4px;
+  padding: 6px 10px;
+  background: #222;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+nav li:hover,
+nav li.selected {
+  background: #444;
+}
+
+#gifs-grid {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  padding: 20px;
+}
+
+.gif-card {
+  background: #111;
+  margin: 10px;
+  padding: 10px;
+  border: 1px solid #333;
+  border-radius: 6px;
+  width: 200px;
+}
+
+.gif-card video {
+  width: 100%;
+  border-radius: 4px;
+}
+
+.gif-title,
+.gif-categoria,
+.gif-tags {
+  margin-top: 5px;
+  font-size: 14px;
+}
+
+.gif-fonte {
+  display: block;
+  margin-top: 6px;
+  color: #8cf;
+  font-size: 12px;
+}
+
+footer {
+  background: #111;
+  padding: 20px;
+  text-align: center;
+  font-size: 14px;
+}
+
+.popup {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.8);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+}
+
+.popup-content {
+  background: #222;
+  padding: 20px;
+  border-radius: 8px;
+}


### PR DESCRIPTION
## Summary
- format the CSS for readability and keep dark theme
- add a `Todas` filter in navigation to reset category selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_688411bc3e34832f80e2b59133523ab7