### PR TITLE
Add image content and handle images

### DIFF
--- a/acervo.txt
+++ b/acervo.txt
@@ -1,2 +1,3 @@
 Morena goza forte | https://thumbs4.redgifs.com/FamousIdealisticGarp-mobile.mp4 | Amadoras | Morenas | morena,sentando,gozo | https://redgifs.com/watch/famousidealisticgarp
 Loira milf cavalgando | https://thumbs4.redgifs.com/BriefMildIchneumonfly-mobile.mp4 | MILF | Loiras | loira,cavalgando,madura | https://redgifs.com/watch/briefmildichneumonfly
+Magrinha dando a buceta | https://casadastop.net/wp-content/uploads/2023/10/magrinha-dando-a-buceta-01.webp | Amadoras | Magrinhas | magrinha,fodendo | https://casadastop.net/

--- a/site.js
+++ b/site.js
@@ -96,7 +96,15 @@ function renderGifs(lista){
   nada.style.display='none';
   lista.forEach(g=>{
     const card=document.createElement('div');card.className='gif-card';
-    const vid=document.createElement('video');vid.src=g.src;vid.autoplay=true;vid.loop=true;vid.muted=true;vid.playsInline=true;
+    let media;
+    if(/\.(mp4|webm)$/i.test(g.src)){
+      media=document.createElement('video');
+      media.src=g.src;
+      media.autoplay=true;media.loop=true;media.muted=true;media.playsInline=true;
+    }else{
+      media=document.createElement('img');
+      media.src=g.src;
+    }
     const title=document.createElement('div');title.className='gif-title';title.textContent=g.title;
     const cat=document.createElement('div');cat.className='gif-categoria';cat.textContent=g.categoria;
     const sub=document.createElement('div');sub.className='gif-subcategoria';sub.textContent=g.subcategoria;
@@ -105,7 +113,7 @@ function renderGifs(lista){
     const btns=document.createElement('div');btns.className='gif-btns';
     const copy=document.createElement('button');copy.textContent='Copiar link';copy.onclick=()=>copiarLink(g.src,copy);
     btns.appendChild(copy);
-    card.append(vid,title,cat,sub,tags,fonte,btns);
+    card.append(media,title,cat,sub,tags,fonte,btns);
     grid.appendChild(card);
   });
 }

--- a/style.css
+++ b/style.css
@@ -65,6 +65,10 @@ nav li.selected {
   width: 100%;
   border-radius: 4px;
 }
+.gif-card img {
+  width: 100%;
+  border-radius: 4px;
+}
 
 .gif-title,
 .gif-categoria,


### PR DESCRIPTION
## Summary
- handle image URLs in `site.js`
- display images in `.gif-card` style
- add explicit content from CasadaStop

## Testing
- `pre-commit` *(fails: pre-commit not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688426d28294832f9abd19be83cb8fb0