### PR TITLE
Add view tracking and top GIFs

### DIFF
--- a/categoria.html
+++ b/categoria.html
@@ -9,6 +9,7 @@
 <body>
   <div class="sidebar">
     <ul>
+      <li><a href="index.html">Início</a></li>
       <li><a href="categoria.html?categoria=Hetero">Hetero</a></li>
       <li><a href="categoria.html?categoria=Gay">Gay</a></li>
       <li><a href="categoria.html?categoria=Trans%20%2F%20Shemales">Trans / Shemales</a></li>

--- a/index.html
+++ b/index.html
@@ -61,6 +61,7 @@
         <input type="text" id="busca" placeholder="Buscar..." autofocus oninput="buscarGifs()">
       </header>
       <main>
+        <h2 id="mais-title" style="display:none;">Mais acessados</h2>
         <section id="gifs-grid"></section>
         <section id="sem-resultados" style="display:none;">
           <p>Nenhum resultado encontrado.</p>

--- a/site.js
+++ b/site.js
@@ -39,7 +39,39 @@ function inicializarSite(){
   if(h1 && selectedCategoria){
     h1.textContent = 'Casa da Putaria – ' + selectedCategoria;
   }
-  buscarGifs();
+  if(!selectedCategoria){
+    mostrarMaisAcessados();
+  }else{
+    buscarGifs();
+  }
+}
+
+function registrarAcesso(src){
+  const key = 'view:' + src;
+  const atual = parseInt(localStorage.getItem(key) || '0', 10);
+  localStorage.setItem(key, atual + 1);
+}
+
+function obterMaisAcessados(limite=10){
+  const contagens = Object.keys(localStorage)
+    .filter(k => k.startsWith('view:'))
+    .map(k => [k.slice(5), parseInt(localStorage.getItem(k) || '0', 10)]);
+  contagens.sort((a,b) => b[1] - a[1]);
+  return contagens.slice(0, limite)
+    .map(([src]) => gifs.find(g => g.src === src))
+    .filter(Boolean);
+}
+
+function mostrarMaisAcessados(){
+  const titulo = document.getElementById('mais-title');
+  const lista = obterMaisAcessados();
+  if(lista.length){
+    if(titulo) titulo.style.display = 'block';
+    renderGifs(lista);
+  }else{
+    if(titulo) titulo.style.display = 'none';
+    buscarGifs();
+  }
 }
 
 function renderSubcategorias(cat){
@@ -102,6 +134,7 @@ function renderGifs(lista){
     const copy=document.createElement('button');copy.textContent='Copiar link';copy.onclick=()=>copiarLink(g.src,copy);
     btns.appendChild(copy);
     card.append(media,title,cat,sub,tags,fonte,btns);
+    media.addEventListener('click',()=>registrarAcesso(g.src));
     grid.appendChild(card);
   });
 }


### PR DESCRIPTION
## Summary
- add return to home link in category page
- show most viewed GIFs on the homepage
- track GIF views via localStorage

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68850e4fedf0832fa8ac1393881a4450